### PR TITLE
Fix Message Order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commit-your-code-bot",
-  "version": "1.2.1",
+  "version": "1.0.1",
   "description": "A verification gate for the Commit Your Code Discord server.",
   "main": "./prod/index.js",
   "scripts": {

--- a/src/modules/question.ts
+++ b/src/modules/question.ts
@@ -61,8 +61,9 @@ export const question = async (
       if (collected.isSelectMenu()) {
         if (collected.values[0] === "no") {
           await interaction.editReply({
-            content: "Correct! Please wait...\nYou will be given access shortly...",
-            components: []
+            content:
+              "Correct! Please wait...\nYou will be given access shortly...",
+            components: [],
           });
           setTimeout(
             async () =>

--- a/src/modules/question.ts
+++ b/src/modules/question.ts
@@ -60,13 +60,9 @@ export const question = async (
     collector.on("collect", async (collected) => {
       if (collected.isSelectMenu()) {
         if (collected.values[0] === "no") {
-          await collected.reply({
-            content: "Correct! Please wait...",
-            ephemeral: true,
-          });
           await interaction.editReply({
-            content: "Congrats! You will be verified shortly.",
-            components: [],
+            content: "Correct! Please wait...\nYou will be given access shortly...",
+            components: []
           });
           setTimeout(
             async () =>
@@ -82,10 +78,11 @@ export const question = async (
               "https://discord.com/channels/810180621930070088/913086515574358066/913110202218319932"
             )
             .setStyle("LINK");
-          await interaction.editReply({
+          await collected.reply({
             content:
               "For more info about the TEC, check out the <#913086515574358066> channel",
             components: [new MessageActionRow().addComponents(button)],
+            ephemeral: true,
           });
         } else {
           await interaction.editReply({


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

<!--A brief description of what your pull request does.-->
The message order sent after verification was problematic.
This PR fixes that issue.

| Before | After |
| :-: | :-: |
| ![Screenshot 2021-12-19 at 12 46 20 AM](https://user-images.githubusercontent.com/62864373/146653220-27c3a75f-bdf3-410c-86dc-ae65f7e7868c.png) | ![Screenshot 2021-12-19 at 12 48 20 AM](https://user-images.githubusercontent.com/62864373/146653265-9ae32a2e-44d0-413b-9b9a-fc29e43579b5.png) |

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
